### PR TITLE
fix: トークンの受け渡しにユーザー登録するように変更、友達数が０でもformが見えたため変更

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,6 +4,7 @@ class UsersController < ApplicationController
         hash = spotify_user.to_hash
         spotify_user = RSpotify::User.new(hash)
         session[:spotify_uid] = spotify_user.id
+        @user = User.find_or_create_by!(spotify_uid: session[:spotify_uid])
         redirect_to top_user_update_path
     end
     def show

--- a/app/views/top/_request_form.html.erb
+++ b/app/views/top/_request_form.html.erb
@@ -1,5 +1,5 @@
 
-<% if not @friends.nil? %>
+<% if not @friends.size == 0 %>
     <%= form_with url: "/music_requests", method: :post do |f| %>
         <% #友達がいない時は表示されない %>
         <%= f.select :user_spotify_uid, @friends %>


### PR DESCRIPTION
fix: トークンの受け渡しにユーザー登録するように変更、友達数が０でもformが見えたため変更